### PR TITLE
Fix typo in number of states

### DIFF
--- a/internals/lifecycle.rst
+++ b/internals/lifecycle.rst
@@ -9,9 +9,9 @@ Kompics Lifecycle
 
     Kompics Lifecycle Overview.
 
-Every Kompics component has a lifecycle of 5 specific states it can be in, which controls what kind of events it will execute and when it will be deallocated (and thus allowed to be garbage collected eventually).
+Every Kompics component has a lifecycle of 6 specific states it can be in, which controls what kind of events it will execute and when it will be deallocated (and thus allowed to be garbage collected eventually).
 
-These 5 states are 
+These 6 states are
 
 .. hlist::
     :columns: 2


### PR DESCRIPTION
Perhaps this is not a typo, and that destroyed is not "counted" as a state? Was a bit confusing while reading it, feels like it should say 6?


![states](https://user-images.githubusercontent.com/11488530/35288335-b578e99e-0064-11e8-9c40-1bffe883ed9f.png)

Well if it is a mistake, then this PR fixes it :beer: 

